### PR TITLE
Form validation kata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Scala training repository used to learn Scala and Functional Programming by solv
 
 ### List of katas:
 
-| # | Kata Statement |  Pull Request |
-|---|----------------|---------------|
-| 1 | [Maxibons](https://github.com/Karumi/MaxibonKataJava#-kata-maxibon-for-java-) | [https://github.com/Karumi/ScalaKatas/pull/1](https://github.com/Karumi/ScalaKatas/pull/1) |
+| # | Kata Statement | PR | Topic |
+|---|----------------|----|-------|
+| 1 | [Maxibons](https://github.com/Karumi/MaxibonKataJava#-kata-maxibon-for-java-) | [https://github.com/Karumi/ScalaKatas/pull/1](https://github.com/Karumi/ScalaKatas/pull/1) | Polymorphic programming |
+| 2 | [Form validation](https://gist.github.com/pedrovgs/d83fe1f096928715a6f31946e557995a) | [https://github.com/Karumi/ScalaKatas/pull/2](https://github.com/Karumi/ScalaKatas/pull/2) | Validated data type|
 
 ### Executing tests:
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalacOptions += "-Ypartial-unification"
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "1.5.0"
 libraryDependencies += "org.typelevel" %% "cats-effect" % "1.1.0"
-libraryDependencies += "eu.timepit" %% "refined" % "0.9.3"
+libraryDependencies += "eu.timepit" %% "refined" % "0.9.4"
 libraryDependencies += "com.github.julien-truffaut" %% "monocle-core" % "1.5.0"
 libraryDependencies += "com.github.julien-truffaut" %% "monocle-macro" % "1.5.0"
 

--- a/src/main/scala/com/github/pedrovgs/scalakatas/formvalidation/FormValidator.scala
+++ b/src/main/scala/com/github/pedrovgs/scalakatas/formvalidation/FormValidator.scala
@@ -1,0 +1,35 @@
+package com.github.pedrovgs.scalakatas.formvalidation
+import java.time.LocalDateTime
+
+import cats.implicits
+import cats.data.ValidatedNec
+
+object FormValidator {
+  type FormValidationResult[A] = ValidatedNec[FormError, A]
+
+  def apply(referenceDate: LocalDateTime, form: Form): FormValidationResult[Form] = {
+    val tuple = (validateFirstName(form.firstName), validateFirstName(form.firstName))
+    tuple.mapN
+  }
+
+  private def validateFirstName(firstName: String): FormValidationResult[String] = ???
+
+}
+
+final case class Form(
+    firstName: String,
+    lastName: String,
+    birthday: LocalDateTime,
+    documentId: String,
+    phone: String,
+    email: String
+)
+
+sealed class FormError {
+  final case class EmptyFirstName(firstName: String)
+  final case class EmptyLastName(lastName: String)
+  final case class UserTooYoung(birthday: LocalDateTime)
+  final case class InvalidDocumentId(documentId: String)
+  final case class InvalidPhone(phone: String)
+  final case class InvalidEmail(email: String)
+}

--- a/src/main/scala/com/github/pedrovgs/scalakatas/formvalidation/FormValidator.scala
+++ b/src/main/scala/com/github/pedrovgs/scalakatas/formvalidation/FormValidator.scala
@@ -13,9 +13,9 @@ object FormValidator {
 
   type FirstName       = Refined[String, NonEmpty]
   type LastName        = Refined[String, NonEmpty]
-  type ValidDocumentId = MatchesRegex[W.`"d{8}[a-zA-Z]{1}"`.T]
+  type ValidDocumentId = MatchesRegex[W.`"""\\d{8}[a-zA-Z]{1}"""`.T]
   type DocumentId      = Refined[String, ValidDocumentId]
-  type ValidPhone      = MatchesRegex[W.`"d{9}"`.T]
+  type ValidPhone      = MatchesRegex[W.`"""\\d{9}"""`.T]
   type Phone           = Refined[String, ValidPhone]
   type Email           = Refined[String, ValidEmail]
 
@@ -73,12 +73,12 @@ object FormValidator {
   private def validatePhone(phone: String): FormValidationResult[Phone] =
     Validated
       .fromEither(refineV[ValidPhone](phone))
-      .leftMap(_ => NonEmptyList.of(InvalidDocumentId(phone)))
+      .leftMap(_ => NonEmptyList.of(InvalidPhone(phone)))
 
   private def validateEmail(email: String): FormValidationResult[Email] =
     Validated
       .fromEither(refineV[ValidEmail](email))
-      .leftMap(_ => NonEmptyList.of(InvalidDocumentId(email)))
+      .leftMap(_ => NonEmptyList.of(InvalidEmail(email)))
 
 }
 

--- a/src/main/scala/com/github/pedrovgs/scalakatas/formvalidation/FormValidator.scala
+++ b/src/main/scala/com/github/pedrovgs/scalakatas/formvalidation/FormValidator.scala
@@ -1,35 +1,91 @@
 package com.github.pedrovgs.scalakatas.formvalidation
+
 import java.time.LocalDateTime
 
-import cats.implicits
-import cats.data.ValidatedNec
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.syntax.apply._
+import eu.timepit.refined.{W, _}
+import eu.timepit.refined.api.{Refined, Validate}
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.string.MatchesRegex
 
 object FormValidator {
-  type FormValidationResult[A] = ValidatedNec[FormError, A]
 
-  def apply(referenceDate: LocalDateTime, form: Form): FormValidationResult[Form] = {
-    val tuple = (validateFirstName(form.firstName), validateFirstName(form.firstName))
-    tuple.mapN
-  }
+  type FirstName       = Refined[String, NonEmpty]
+  type LastName        = Refined[String, NonEmpty]
+  type ValidDocumentId = MatchesRegex[W.`"d{8}[a-zA-Z]{1}"`.T]
+  type DocumentId      = Refined[String, ValidDocumentId]
+  type ValidPhone      = MatchesRegex[W.`"d{9}"`.T]
+  type Phone           = Refined[String, ValidPhone]
+  type Email           = Refined[String, ValidEmail]
 
-  private def validateFirstName(firstName: String): FormValidationResult[String] = ???
+  case class ValidEmail()
+  implicit val emailValidate: Validate.Plain[String, ValidEmail] =
+    Validate.fromPredicate(e => e.contains("@"), p => s"$p is not a valid email", ValidEmail())
+
+  final case class UnsafeForm(
+      firstName: String,
+      lastName: String,
+      birthday: LocalDateTime,
+      documentId: String,
+      phone: String,
+      email: String
+  )
+  final case class Form(
+      firstName: FirstName,
+      lastName: LastName,
+      birthday: LocalDateTime,
+      documentId: DocumentId,
+      phone: Phone,
+      email: Email
+  )
+  type FormValidationResult[A] = ValidatedNel[FormError, A]
+
+  def apply(referenceDate: LocalDateTime, form: UnsafeForm): FormValidationResult[Form] =
+    (validateFirstName(form.firstName),
+     validateLastName(form.lastName),
+     validateBirthday(referenceDate, form.birthday),
+     validateDocumentId(form.documentId),
+     validatePhone(form.phone),
+     validateEmail(form.email)).mapN(Form)
+
+  private def validateFirstName(firstName: String): FormValidationResult[FirstName] =
+    Validated
+      .fromEither(refineV[NonEmpty](firstName))
+      .leftMap(_ => NonEmptyList.of(EmptyFirstName(firstName)))
+
+  private def validateLastName(lastName: String): FormValidationResult[LastName] =
+    Validated
+      .fromEither(refineV[NonEmpty](lastName))
+      .leftMap(_ => NonEmptyList.of(EmptyLastName(lastName)))
+
+  private def validateBirthday(refDate: LocalDateTime, birthday: LocalDateTime): FormValidationResult[LocalDateTime] =
+    if (birthday.compareTo(refDate.minusYears(18)) <= 0) {
+      Validated.valid(birthday)
+    } else {
+      Validated.invalidNel(UserTooYoung(birthday))
+    }
+  private def validateDocumentId(documentId: String): FormValidationResult[DocumentId] =
+    Validated
+      .fromEither(refineV[ValidDocumentId](documentId))
+      .leftMap(_ => NonEmptyList.of(InvalidDocumentId(documentId)))
+
+  private def validatePhone(phone: String): FormValidationResult[Phone] =
+    Validated
+      .fromEither(refineV[ValidPhone](phone))
+      .leftMap(_ => NonEmptyList.of(InvalidDocumentId(phone)))
+
+  private def validateEmail(email: String): FormValidationResult[Email] =
+    Validated
+      .fromEither(refineV[ValidEmail](email))
+      .leftMap(_ => NonEmptyList.of(InvalidDocumentId(email)))
 
 }
 
-final case class Form(
-    firstName: String,
-    lastName: String,
-    birthday: LocalDateTime,
-    documentId: String,
-    phone: String,
-    email: String
-)
-
-sealed class FormError {
-  final case class EmptyFirstName(firstName: String)
-  final case class EmptyLastName(lastName: String)
-  final case class UserTooYoung(birthday: LocalDateTime)
-  final case class InvalidDocumentId(documentId: String)
-  final case class InvalidPhone(phone: String)
-  final case class InvalidEmail(email: String)
-}
+sealed trait FormError
+case class EmptyFirstName(firstName: String)           extends FormError
+final case class EmptyLastName(lastName: String)       extends FormError
+final case class UserTooYoung(birthday: LocalDateTime) extends FormError
+final case class InvalidDocumentId(documentId: String) extends FormError
+final case class InvalidPhone(phone: String)           extends FormError
+final case class InvalidEmail(email: String)           extends FormError

--- a/src/test/scala/com/github/pedrovgs/formvalidation/ArbitraryForms.scala
+++ b/src/test/scala/com/github/pedrovgs/formvalidation/ArbitraryForms.scala
@@ -1,0 +1,20 @@
+package com.github.pedrovgs.formvalidation
+import java.time.LocalDateTime
+
+import com.github.pedrovgs.scalakatas.formvalidation.FormValidator.{FirstName, LastName, UnsafeForm}
+import eu.timepit.refined.scalacheck.string._
+import org.scalacheck.{Arbitrary, Gen}
+
+trait ArbitraryForms {
+
+  implicit val arbitraryForm: Arbitrary[UnsafeForm] = Arbitrary {
+    for {
+      firstName  <- Arbitrary.arbitrary[FirstName]
+      lastName   <- Arbitrary.arbitrary[LastName]
+      birthday   <- Gen.const(LocalDateTime.MIN)
+      documentId <- Gen.const("44632508A")
+      phone      <- Gen.const("999673292")
+      email      <- Gen.const("p@k.com")
+    } yield UnsafeForm(firstName.value, lastName.value, birthday, documentId, phone, email)
+  }
+}

--- a/src/test/scala/com/github/pedrovgs/formvalidation/FormValidatorSpec.scala
+++ b/src/test/scala/com/github/pedrovgs/formvalidation/FormValidatorSpec.scala
@@ -1,0 +1,58 @@
+package com.github.pedrovgs.formvalidation
+import java.time.LocalDateTime
+
+import cats.data.{NonEmptyList, Validated}
+import com.github.pedrovgs.scalakatas.formvalidation.FormValidator.UnsafeForm
+import com.github.pedrovgs.scalakatas.formvalidation._
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class FormValidatorSpec extends FlatSpec with Matchers with PropertyChecks with ArbitraryForms {
+
+  it should "indicate all the invalid values in an unsafe form with every field as invalid" in {
+    val form = UnsafeForm(
+      firstName = "",
+      lastName = "",
+      birthday = LocalDateTime.now(),
+      documentId = "48632500",
+      phone = "6799",
+      email = "pedro"
+    )
+
+    val result = FormValidator(LocalDateTime.now(), form)
+
+    result shouldBe Validated.invalid(
+      NonEmptyList.of(
+        EmptyFirstName(form.firstName),
+        EmptyLastName(form.lastName),
+        UserTooYoung(form.birthday),
+        InvalidDocumentId(form.documentId),
+        InvalidPhone(form.phone),
+        InvalidEmail(form.email)
+      ))
+  }
+
+  it should "indicate just one invalid value in an unsafe form where just one field is invalid" in {
+    val form = UnsafeForm(
+      firstName = "Pedro",
+      lastName = "Gómez",
+      birthday = LocalDateTime.MIN,
+      documentId = "38632509C",
+      phone = "677673297",
+      email = "pedro"
+    )
+
+    val result = FormValidator(LocalDateTime.now(), form)
+
+    result shouldBe Validated.invalid(
+      NonEmptyList.of(
+        InvalidEmail(form.email)
+      ))
+  }
+
+  it should "consider as valid form with evey field as valid" in {
+    forAll { form: UnsafeForm =>
+      FormValidator(LocalDateTime.now(), form).isValid shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
### :tophat: What is the goal?

To solve a simple exercise using [Validated](https://arrow-kt.io/docs/arrow/data/validated/) data type. The exercise statement can be found [here](https://gist.github.com/pedrovgs/d83fe1f096928715a6f31946e557995a). In this exercise, the main goal is to validate a form returning all the errors if there are some.

### How is it being implemented?

To implement this Kata we decided to use [Refined types](https://github.com/fthomas/refined) in Scala. However, the usage of these types guarantees that the ``Form`` type should be instantiated in a valid way using literals or should be instantiated using ``refinedV`` where the possible validation error should be handled before instantiating any field. That's why we created the type ``UnsafeForm``. As most of the time our values are generated in runtime we needed a type to hold all this information and then a ``FormValidator`` we implemented easily thanks to these functions:

* ``mapN``. Letting us transform a ``Tuple6`` into a ``ValidatedNel<FormError, Form>``. You can see here how the usage of implicits let us don't indicate the ``NonEmptyList`` semigroup instance or the applicative instance we needed in other solutions like [the Arrow one written in Kotlin](https://github.com/pedrovgs/KotlinKatas/pull/4)
* The definition of the types using refined:

```scala
type FirstName       = Refined[String, NonEmpty]
  type LastName        = Refined[String, NonEmpty]
  type ValidDocumentId = MatchesRegex[W.`"""\\d{8}[a-zA-Z]{1}"""`.T]
  type DocumentId      = Refined[String, ValidDocumentId]
  type ValidPhone      = MatchesRegex[W.`"""\\d{9}"""`.T]
  type Phone           = Refined[String, ValidPhone]
  type Email           = Refined[String, ValidEmail]

  case class ValidEmail()
  implicit val emailValidate: Validate.Plain[String, ValidEmail] =
    Validate.fromPredicate(e => e.contains("@"), p => s"$p is not a valid email", ValidEmail())
```

We created our own type named ``ValidEmail`` and used the already implemented ones to compose the rest of the types. The usage of regex was really interesting combined with the type definition.

* ``Validated.fromEither``. Letting us transform the ``Either`` generated by ``refineV`` into a ``Validated`` as follows:

```scala
 Validated
      .fromEither(refineV[NonEmpty](firstName))
      .leftMap(_ => NonEmptyList.of(EmptyFirstName(firstName)))
```

Last but not least, there is an interesting point when taking a look at the test coverage. We couldn't get the generators working for the types based on ``MatchesRegex`` type. I guess this is because it's not possible to generate values matching the expression in a reasonable time. So in this scenario, we couldn't automatically derive our generators as we did in the previous kata 😢 

If you are wondering why we used ``Validated`` instead of ``Either`` this blog post will resolve your question: https://www.tobyhobson.com/cats-validated/

### How can it be tested?

Automatically! :robot: I've added some automated tests I'd recommend you to review :smiley: